### PR TITLE
feat: add explicit error on null sponsorship node tier

### DIFF
--- a/src/getSponsorshipNodes.ts
+++ b/src/getSponsorshipNodes.ts
@@ -26,9 +26,13 @@ interface ResultFields {
 	sponsorshipsAsMaintainer: SponsorshipsAsMaintainer;
 }
 
+type NullableProperties<T> = {
+	[P in keyof T]: T[P] | null;
+};
+
 interface SponsorshipsAsMaintainer {
 	edges: {
-		node: SponsorshipNode;
+		node: NullableProperties<SponsorshipNode>;
 	}[];
 }
 
@@ -88,5 +92,19 @@ export async function getSponsorshipsAsMaintainer({
 	const { sponsorshipsAsMaintainer } =
 		"user" in result ? result.user : result.viewer;
 
-	return sponsorshipsAsMaintainer.edges.map((edge) => edge.node);
+	const nodes = sponsorshipsAsMaintainer.edges.map((edge) => edge.node);
+
+	if (!isFullResponse(nodes)) {
+		throw new Error(
+			"Sponsorship data seems to be missing. Do you have the right token permissions?"
+		);
+	}
+
+	return nodes;
+}
+
+function isFullResponse(
+	nodes: NullableProperties<SponsorshipNode>[]
+): nodes is SponsorshipNode[] {
+	return nodes.every((node) => !!node.tier);
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #19
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/github-sponsors-to-markdown/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/github-sponsors-to-markdown/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

If there's any sponsorship node with a `null` tier, this now throws an explicit error.