### PR TITLE
fix: make tiers ignore object property orders

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,16 +15,19 @@ export async function githubSponsorsToMarkdown({
 }: GithubSponsorsToMarkdownOptions) {
 	const logger = verbose ? console.log.bind(console) : undefined;
 	const sponsorshipNodes = await getSponsorshipsAsMaintainer({ logger, login });
+	const tiersSorted = Object.entries(tiers).sort(
+		([a], [b]) => tiers[b].minimum - tiers[a].minimum
+	);
 
 	const sponsorshipsSorted = sponsorshipNodes
 		.filter((node) => !node.isOneTimePayment)
-		.sort((a, b) => b.sponsorEntity.login.localeCompare(a.sponsorEntity.login));
+		.sort((a, b) => a.sponsorEntity.login.localeCompare(b.sponsorEntity.login));
 
 	logger?.(
 		"Sponsorships, sorted:",
 		JSON.stringify(sponsorshipsSorted, null, 4)
 	);
-	const tierGroups = groupSponsorships(sponsorshipsSorted, tiers);
+	const tierGroups = groupSponsorships(sponsorshipsSorted, tiersSorted);
 	const width = `${Math.floor(100 / Object.keys(tierGroups).length)}%`;
 
 	const tierGroupsSorted = Object.fromEntries(
@@ -80,10 +83,9 @@ export async function githubSponsorsToMarkdown({
 
 	function groupSponsorships(
 		sponsorships: SponsorshipNode[],
-		tiers: Record<string, SponsorshipTier>
+		tierEntries: [string, SponsorshipTier][]
 	) {
 		const tierGroups: Record<string, SponsorshipDescription[]> = {};
-		const tierEntries = Object.entries(tiers);
 
 		logger?.("Collected tier entries:", JSON.stringify(tierEntries, null, 4));
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #86
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/github-sponsors-to-markdown/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/github-sponsors-to-markdown/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Sorts the tiers earlier in code.