### PR TITLE
fix: manually set avatar image sizes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,7 @@ export async function githubSponsorsToMarkdown({
 
 		return [
 			`\t\t\t\t<a href="${url}">`,
-			`\t\t\t\t\t<img alt="${name}" src="${url}.png?size=${tier.size}" />`,
+			`\t\t\t\t\t<img alt="${name}" height="${tier.size}px" src="${url}.png?size=${tier.size}" width="${tier.size}px" />`,
 			`\t\t\t\t</a>`,
 		].join("\n");
 	}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #174
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/github-sponsors-to-markdown/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/github-sponsors-to-markdown/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Manually sets `height` and `width` on the generated images.