### PR TITLE
fix: allow auth option to defualt to process.env.GH_TOKEN

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,12 +11,9 @@ export async function githubSponsorsToMarkdown({
 	tiers = defaultOptions.tiers,
 	verbose,
 }: GithubSponsorsToMarkdownOptions) {
+	auth ||= process.env.GH_TOKEN;
 	if (!auth) {
-		if (!process.env.GH_TOKEN) {
-			throw new Error(`Please provide an auth token.`);
-		}
-
-		auth = process.env.GH_TOKEN;
+		throw new Error(`Please provide an auth token (process.env.GH_TOKEN).`);
 	}
 
 	const logger = verbose ? console.log.bind(console) : undefined;

--- a/src/options.ts
+++ b/src/options.ts
@@ -5,7 +5,7 @@ export interface SponsorshipTier {
 }
 
 export interface GithubSponsorsToMarkdownOptions {
-	auth: string;
+	auth?: string;
 	login?: string;
 	tiers?: Record<string, SponsorshipTier>;
 	verbose?: boolean;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #176
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/github-sponsors-to-markdown/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/github-sponsors-to-markdown/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Correctly marks `auth` as an optional options property. Also cleans up the checking/defaulting logic a teeny bit.